### PR TITLE
65 add citation for new ctxr paper

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -40,6 +40,10 @@ To install the current development version, run the following command:
 
 Users don't need a API key to install ctxR, but will need to supply an API key to use ctxR and access data. A *FREE* API key can be obtained by emailing the [CTX API Admins](mailto:ccte_api@epa.gov).
 
+If you use [ctxR](https://cran.r-project.org/package=ctxR) in published research, please cite the following paper:
+
+Kruse, PM, Ring, CL, Paul Friedman, K, Feshuk, M, Brown, J, Thunes, C, & Rashid, A. (2025). ctxR: Utilities for interacting with the CTX APIs. _*NAM Journal*_, 100031. doi: [10.1016/j.namjnl.2025.100031](https://doi.org/10.1016/j.namjnl.2025.100031)
+
 ### Disclaimer
 
 The United States Environmental Protection Agency (EPA) GitHub project code is provided on an "as is" basis and the user assumes responsibility for its use. EPA has relinquished control of the information and no longer has responsibility to protect the integrity, confidentiality, or availability of the information. Any reference to specific commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply their endorsement, recommendation or favoring by EPA. The EPA seal and logo shall not be used in any manner to imply endorsement of any commercial product or activity by EPA or the United States Government.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Users don’t need a API key to install ctxR, but will need to supply an
 API key to use ctxR and access data. A *FREE* API key can be obtained by
 emailing the [CTX API Admins](mailto:ccte_api@epa.gov).
 
+If you use [ctxR](https://cran.r-project.org/package=ctxR) in published
+research, please cite the following paper:
+
+Kruse, PM, Ring, CL, Paul Friedman, K, Feshuk, M, Brown, J, Thunes, C, &
+Rashid, A. (2025). ctxR: Utilities for interacting with the CTX APIs.
+**NAM Journal**, 100031. doi:
+[10.1016/j.namjnl.2025.100031](https://doi.org/10.1016/j.namjnl.2025.100031)
+
 ### Disclaimer
 
 The United States Environmental Protection Agency (EPA) GitHub project

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,28 @@
+bibentry(
+  bibtype  = "Article",
+  title    = "ctxR: Utilities for interacting with the CTX APIs",
+  author   = c(person(given = c("Paul", "M."),
+                      family = "Kruse"),
+               person(given = c("Caroline", "L."),
+                      family = "Ring"),
+               person(given = "Katie",
+                      family = c("Paul", "Friedman")),
+               person(given = "Madison",
+                      family = "Feshuk"),
+               person(given = "Jason",
+                      family = "Brown"),
+               person(given = "Carter",
+                      family = "Thunes"),
+               person(given = "Asif",
+                      family = "Rashid")),
+  journal  = "NAM Journal",
+  year     = "2025",
+  volume   = "1",
+  pages    = "100031",
+  doi      = "10.1016/j.namjnl.2025.100031",
+  textVersion =
+  paste("Kruse PM, Ring CL, Paul Friedman K, Feshuk M, Brown J, Thunes C, Rashid A (2025).",
+        "ctxR: Utilities for interacting with the CTX APIs.",
+        "NAM Journal, 1, 100031",
+        "doi:10.1016/j.namjnl.2025.100031")
+)


### PR DESCRIPTION
Added citation information to Readme document and populated data for use with `citation('ctxR')`. This closes #65 .